### PR TITLE
Show 5min gap between each appointment visually,

### DIFF
--- a/app/src/main/java/screens/CalendarScreen.kt
+++ b/app/src/main/java/screens/CalendarScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -173,9 +174,31 @@ fun AppointmentRow(appointment: Appointment) {
                 modifier = Modifier.padding(end = 16.dp)
             ) {
                 val hora = appointment.date.split("T").getOrNull(1)?.substring(0, 5) ?: "--:--"
+                
+                // Calcular hora final (55 minutos después de la hora de inicio)
+                val horaFinal = remember(hora) {
+                    try {
+                        val timeParts = hora.split(":")
+                        if (timeParts.size == 2) {
+                            val hour = timeParts[0].toIntOrNull() ?: 0
+                            val minute = timeParts[1].toIntOrNull() ?: 0
+                            
+                            val totalMinutes = hour * 60 + minute + 55
+                            val finalHour = (totalMinutes / 60) % 24
+                            val finalMinute = totalMinutes % 60
+                            
+                            String.format("%02d:%02d", finalHour, finalMinute)
+                        } else {
+                            "--:--"
+                        }
+                    } catch (e: Exception) {
+                        "--:--"
+                    }
+                }
+                
                 Text(
-                    text = hora,
-                    fontSize = 18.sp,
+                    text = "$hora - $horaFinal",
+                    fontSize = 16.sp,
                     fontWeight = FontWeight.ExtraBold,
                     color = Color(0xFF323232)
                 )

--- a/app/src/main/java/screens/SelectAvailableSlotsScreen.kt
+++ b/app/src/main/java/screens/SelectAvailableSlotsScreen.kt
@@ -69,7 +69,7 @@ fun SelectAvailableSlotsScreen(
                         fontSize = 14.sp
                     )
                     Text(
-                        "Hora: ${viewModel.selectedAppointmentSlot?.slotStart ?: ""}",
+                        "Hora: ${viewModel.selectedAppointmentSlot?.slotStart ?: ""} - ${viewModel.selectedAppointmentSlot?.slotEnd ?: ""}",
                         fontSize = 14.sp
                     )
                     Text(
@@ -387,8 +387,8 @@ fun SelectAvailableSlotsScreen(
                                                                         verticalArrangement = Arrangement.Center
                                                                     ) {
                                                                         Text(
-                                                                            slot.slotStart,
-                                                                            fontSize = 16.sp,
+                                                                            "${slot.slotStart} - ${slot.slotEnd}",
+                                                                            fontSize = 14.sp,
                                                                             fontWeight = FontWeight.Bold
                                                                         )
                                                                         Text(


### PR DESCRIPTION
Summary of Modified Files
1. [SelectAvailableSlotsScreen.kt]
Updated appointment time display: Modified the slot button to show the complete time range format "HH:MM - HH:MM" (e.g., "8:30 - 9:25") instead of just the start time
Enhanced confirmation dialog: Updated to display both start and end times in the confirmation message
2. [CalendarScreen.kt]
Added remember import: Imported the remember composable for state management
Enhanced AppointmentRow composable: Implemented automatic end-time calculation by adding 55 minutes to the start time
Improved visual presentation: Now displays the complete appointment duration "HH:MM - HH:MM" in the calendar view