### PR TITLE
fix: Actualizar UI en tiempo real al eliminar citas

### DIFF
--- a/app/src/main/java/screens/DeleteAppointmentScreen.kt
+++ b/app/src/main/java/screens/DeleteAppointmentScreen.kt
@@ -90,8 +90,6 @@ fun DeleteAppointmentScreen(
                                 onSuccess = {
                                     showConfirmDelete = false
                                     appointmentToDelete = null
-                                    
-                                    viewModel.applyAllFilters()
                                 },
                                 onError = {
                                     // Handle error

--- a/app/src/main/java/viewmodel/AppointmentSearcherViewModel.kt
+++ b/app/src/main/java/viewmodel/AppointmentSearcherViewModel.kt
@@ -11,7 +11,7 @@ import com.example.easyteeth.model.Appointment
 class AppointmentSearcherViewModel : ViewModel() {
     private val api = RetrofitClient.instance.create(AppointmentApiEndpoints::class.java)
 
-    private var allAppointments = listOf<Appointment>()
+    private var allAppointments = mutableListOf<Appointment>()
     var filteredAppointments = mutableStateListOf<Appointment>()
     var isLoading by mutableStateOf(false)
 
@@ -46,7 +46,8 @@ class AppointmentSearcherViewModel : ViewModel() {
                         android.util.Log.d("AppointmentSearcher", "Appointment: ${appointment.patient?.name} - ${appointment.date}")
                     }
 
-                    allAppointments = body
+                    allAppointments.clear()
+                    allAppointments.addAll(body)
 
                     // Extraer opciones únicas para los desplegables
                     treatmentOptions.clear()
@@ -105,6 +106,10 @@ class AppointmentSearcherViewModel : ViewModel() {
                 val response = api.deleteAppointment(appointmentId)
                 if (response.isSuccessful) {
                     android.util.Log.d("AppointmentSearcher", "Appointment deleted: $appointmentId")
+                    // Eliminar la cita de la lista local inmediatamente
+                    allAppointments.removeAll { it.id == appointmentId }
+                    // Aplicar filtros para actualizar la UI
+                    applyAllFilters()
                     onSuccess()
                 } else {
                     android.util.Log.e("AppointmentSearcher", "Delete error: ${response.code()}")


### PR DESCRIPTION
Fixed the problem where deleted appointments were not visually updated in the "Delete Appointments" screen until exiting and re-entering the screen.

Changes Made:


1. [AppointmentSearcherViewModel.kt]
Data structure update: Changed allAppointments from List to MutableList to allow real-time modifications
Improved fetchAllAppointments method: Now uses .clear() and .addAll() instead of direct reassignment
Enhanced deleteAppointment method:
Immediately removes the appointment from the local list after backend confirmation: allAppointments.removeAll { it.id == appointmentId }
Automatically calls applyAllFilters() to refresh the UI


2. [DeleteAppointmentScreen.kt]
Simplified onSuccess callback: Removed redundant applyAllFilters() call since it now executes automatically in the ViewModel
Update Flow:
User confirms deletion
API deletes appointment from backend
Appointment is immediately removed from local list
Filters are automatically applied
UI updates in real-time without requiring screen exit/re-entryFixed the problem where deleted appointments were not visually updated in the "Delete Appointments" screen until exiting and re-entering the screen.

